### PR TITLE
fix weird startup crashes on c++ projects

### DIFF
--- a/WaterInteractionPlugin/Source/WaterInteractionPlugin/WaterInteractionPlugin.Build.cs
+++ b/WaterInteractionPlugin/Source/WaterInteractionPlugin/WaterInteractionPlugin.Build.cs
@@ -7,7 +7,6 @@ public class WaterInteractionPlugin : ModuleRules
 	public WaterInteractionPlugin(ReadOnlyTargetRules Target) : base(Target)
 	{
 		PCHUsage = ModuleRules.PCHUsageMode.UseExplicitOrSharedPCHs;
-		bUsePrecompiled=true;
 		
 		PublicIncludePaths.AddRange(
 			new string[] {

--- a/WaterInteractionPlugin/WaterInteractionPlugin.uplugin
+++ b/WaterInteractionPlugin/WaterInteractionPlugin.uplugin
@@ -4,7 +4,7 @@
 	"VersionName": "1.1.3",
 	"FriendlyName": "WaterInteractionPlugin",
 	"Description": "FluidNinjaLIVE + Oceanology Integration",
-	"Category": "Water",
+	"Category": "Ocean",
 	"CreatedBy": "Marin Zujić",
 	"CreatedByURL": "https://www.marinzujic.com/",
 	"DocsURL": "https://github.com/Sartaq12/WaterInteractionPlugin/blob/main/README.md",


### PR DESCRIPTION
bUsePrecompiled=true; on Ln10 in WaterInteractionPlugin.Build.cs
was causing some users to not be able to open their projects with the plugin.
Without it that's fixed